### PR TITLE
Fix performance issue / "known oddity"

### DIFF
--- a/EverhoodCB_BattleBrowser/BattleBrowser.cs
+++ b/EverhoodCB_BattleBrowser/BattleBrowser.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using UnityEngine.SceneManagement;
 
 namespace EverhoodCB_BattleBrowser
 {
@@ -26,6 +27,7 @@ namespace EverhoodCB_BattleBrowser
         public static KeyCode nextKey;
         public static int nextButton;
         public static int prevButton;
+        public static string sceneName;
 
         private EverhoodModInstaller everhoodMI;
         private Joystick input = null;
@@ -37,6 +39,7 @@ namespace EverhoodCB_BattleBrowser
             nextKey = KeyCode.E;
             nextButton = 5;
             prevButton = 4;
+            sceneName = SceneManager.GetActiveScene().name;
         }
 
         public void Start()
@@ -71,6 +74,8 @@ namespace EverhoodCB_BattleBrowser
 
         public void Update()
         {
+            if (SceneManager.GetActiveScene().name != sceneName) return;
+
             if (input == null && EverhoodInput.player.controllers.joystickCount > 0)
             {
                 input = EverhoodInput.player.controllers.Joysticks[0];

--- a/EverhoodCB_BattleBrowser/EverhoodCB_BattleBrowser.csproj
+++ b/EverhoodCB_BattleBrowser/EverhoodCB_BattleBrowser.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -9,9 +8,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EverhoodCB_BattleBrowser</RootNamespace>
     <AssemblyName>EverhoodCB_BattleBrowser</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFramework>net472</TargetFramework>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,38 +31,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Everhood\Everhood\EverhoodCustomBattles\BepInEx\core\0Harmony.dll</HintPath>
-    </Reference>
+    <PackageReference
+      Include="BepInEx.Analyzers"
+      PrivateAssets="all"
+      Version="1.*"
+    />
+    <PackageReference
+      Include="BepInEx.Core"
+      Version="5.4.*"
+    />
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Everhood\Everhood\EverhoodCustomBattles\EverhoodCustomBattles_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(MSBuildProgramFiles32)\Steam\steamapps\common\Everhood\Everhood\EverhoodCustomBattles\EverhoodCustomBattles_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <Publicize>True</Publicize>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="BepInEx">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Everhood\Everhood\EverhoodCustomBattles\BepInEx\core\BepInEx.dll</HintPath>
+    <Reference Include="Rewired_Core">
+      <HintPath>$(MSBuildProgramFiles32)\Steam\steamapps\common\Everhood\Everhood\EverhoodCustomBattles\EverhoodCustomBattles_Data\Managed\Rewired_Core.dll</HintPath>
     </Reference>
-    <Reference Include="Rewired_Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Everhood\Everhood\EverhoodCustomBattles\EverhoodCustomBattles_Data\Managed\Rewired_Core.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Everhood\Everhood\EverhoodCustomBattles\EverhoodCustomBattles_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(MSBuildProgramFiles32)\Steam\steamapps\common\Everhood\Everhood\EverhoodCustomBattles\EverhoodCustomBattles_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Everhood\Everhood\EverhoodCustomBattles\EverhoodCustomBattles_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(MSBuildProgramFiles32)\Steam\steamapps\common\Everhood\Everhood\EverhoodCustomBattles\EverhoodCustomBattles_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="BattleBrowser.cs" />
-    <Compile Include="BrowserPatches.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/EverhoodCB_BattleBrowser/NuGet.Config
+++ b/EverhoodCB_BattleBrowser/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
In a battle scene, the GameObject containing an instance of EverhoodModInstaller is deleted. Thus, in the plugin's Update() logic (which is called every frame), it would always call FindObjectByType<EverhoodModInstaller>() and fail to find it. The more GameObjects in the battle's scene, the slower this call would be, thus some battles were hit exceptionally hard while other battles suffered only a barely noticeable impact.

This PR solves the issue by skipping the entire Update function when the active scene is not the modlist page. This could be optimized further by disabling or reenabling the plugin entirely upon scene change, but I'm too lazy to do all that :)